### PR TITLE
Style and test fixes for save

### DIFF
--- a/src/spectro_inlets_quantification/calibration.py
+++ b/src/spectro_inlets_quantification/calibration.py
@@ -242,14 +242,20 @@ class Calibration(SensitivityList):
         Args:
             file_name (str): Name of file to save in, must end in .yml
                 If not specified, will use self.name + ".yml"
-            cal_dir: Path to directory to save calibration in, defaults to
-                :attr:`Config.calibration_directory`
+            cal_dir: Path to directory to save calibration in. Defaults to
+                ``:attr:`config.aux_data_directory` / "calibrations"`` if the
+                `aux_data_directory` is set and if not defaults to
+                ``:attr:`config.data_directory` / "calibrations"``
         Raises:
             ValueError: if name not specified and "None" in self.name
                 (this is the case if name wasn't specified
                 and either date or setup wasn't specified when initiating)
         """
-        file_name_with_suffix = Path(file_name).with_suffix(".yml")
+        if file_name:
+            file_name_with_suffix = Path(file_name).with_suffix(".yml")
+        else:
+            file_name_with_suffix = Path(self.name + ".yml")
+
         path_to_yaml = CONFIG.get_save_destination(
             data_file_type="calibrations",
             filepath=file_name_with_suffix,

--- a/src/spectro_inlets_quantification/calibration.py
+++ b/src/spectro_inlets_quantification/calibration.py
@@ -8,17 +8,17 @@ Equivalently initiating a `SensitivityList` from a ``sf_list`` of SensitivityFac
 the way to make a calibration during dev-time is to add CalPoints to a `cal_list` and
 then use that to initiate a `Calibration`.
 """
-import yaml
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import attr
+import yaml
 
 from .chip import Chip
 from .config import Config
 from .constants import STANDARD_MOL_COLORS
-from .custom_types import YAMLVALUE, MASS, MASSLIST, MOL, MOLLIST, PATHLIKE
+from .custom_types import MASS, MASSLIST, MOL, MOLLIST, PATHLIKE, YAMLVALUE
 from .molecule import Molecule, MoleculeDict
 from .sensitivity import (  # noqa
     SENSITIVITYLIST_FILTER_TYPE,

--- a/src/spectro_inlets_quantification/chip.py
+++ b/src/spectro_inlets_quantification/chip.py
@@ -99,8 +99,10 @@ class Chip:
         Args:
             file_name: Name of the .yml file. Should include the file suffix;
                 file_name.endswith(".yml")
-            chip_dir: path to directory to save chip in, defaults to :attr:`Config.chip_directory`
-                the spitze chips folder.
+            chip_dir: path to directory to save chip in. Defaults to
+                ``:attr:`config.aux_data_directory` / "chips"`` if the
+                `aux_data_directory` is set and if not defaults to
+                ``:attr:`config.data_directory` / "chips"``
             kwargs: (other) key word arguments are added to self_as_dict before saving.
         """
         file_name_with_suffix = Path(file_name).with_suffix(".yml")

--- a/src/spectro_inlets_quantification/chip.py
+++ b/src/spectro_inlets_quantification/chip.py
@@ -16,12 +16,12 @@ Variables with abbreviated or non-descriptive names, e.g. physical quantities:
 The variable names are from .../Industrial R&D/Quantification/Reports/MS_Theory_v1.0
 """
 
-import yaml
 from math import isclose
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Union, cast
 
 import numpy as np
+import yaml
 from scipy.optimize import fsolve  # type: ignore
 
 from .config import Config

--- a/src/spectro_inlets_quantification/config.py
+++ b/src/spectro_inlets_quantification/config.py
@@ -87,10 +87,7 @@ class Config(metaclass=Singleton):
         )
 
     def get_save_destination(
-        self,
-        data_file_type: str,
-        filepath: Path,
-        override_destination_dir: Optional[Path] = None
+        self, data_file_type: str, filepath: Path, override_destination_dir: Optional[Path] = None
     ) -> Path:
         """Return the best destination for a specific data file. Create the folder if needed.
 

--- a/src/spectro_inlets_quantification/molecule.py
+++ b/src/spectro_inlets_quantification/molecule.py
@@ -180,15 +180,19 @@ class Molecule:
     def save(self, mol_dir: Optional[PATH_OR_STR] = None, file_name: Optional[str] = None) -> None:
         """Save the `as_dict` form of the molecule to a yaml file.
 
-        Saves in `CONFIG.aux_data_directory / "molecules"` by default. This is the
-        user's quant data library (as opposed to the included library).
+        Saves in `CONFIG.aux_data_directory / "molecules"` if it is set (this is the
+        user's quant data library, as opposed to the included library). If it is not set,
+        saves in `CONFIG.data_directory / "molecules"`.
 
         Args:
-            mol_dir: Path to directory to save molecule in, defaults to
-                :attr:`Config.molecule_directory`
+            mol_dir: Path to directory to save molecule in. Defaults are as outlinied above.
             file_name: Name of the yaml file, including the file extension ".yml"
         """
-        file_name_with_suffix = Path(file_name).with_suffix(".yml")
+        if file_name:
+            file_name_with_suffix = Path(file_name).with_suffix(".yml")
+        else:
+            file_name_with_suffix = Path(self.name + ".yml")
+
         path_to_yaml = CONFIG.get_save_destination(
             data_file_type="molecules",
             filepath=file_name_with_suffix,

--- a/src/spectro_inlets_quantification/molecule.py
+++ b/src/spectro_inlets_quantification/molecule.py
@@ -177,7 +177,7 @@ class Molecule:
         """Normalized version of self.spectrum."""
         return self.calc_norm_spectrum()
 
-    def save(self, mol_dir: Optional[PATH_OR_STR] = None, file_name: Optional[str] = None) -> None:
+    def save(self, file_name: Optional[str] = None, mol_dir: Optional[PATH_OR_STR] = None) -> None:
         """Save the `as_dict` form of the molecule to a yaml file.
 
         Saves in `CONFIG.aux_data_directory / "molecules"` if it is set (this is the
@@ -185,8 +185,8 @@ class Molecule:
         saves in `CONFIG.data_directory / "molecules"`.
 
         Args:
-            mol_dir: Path to directory to save molecule in. Defaults are as outlinied above.
             file_name: Name of the yaml file, including the file extension ".yml"
+            mol_dir: Path to directory to save molecule in. Defaults are as outlinied above.
         """
         if file_name:
             file_name_with_suffix = Path(file_name).with_suffix(".yml")

--- a/src/spectro_inlets_quantification/molecule.py
+++ b/src/spectro_inlets_quantification/molecule.py
@@ -117,7 +117,7 @@ class Molecule:
 
     """
 
-    name: Optional[str] = field(default=None)
+    name: str = field()
     real_name: Optional[str] = field(default=None)
     formula: Optional[str] = field(default=None)
     spectrum: Optional[MASS_TO_FLOAT] = field(default=None)

--- a/src/spectro_inlets_quantification/sensitivity.py
+++ b/src/spectro_inlets_quantification/sensitivity.py
@@ -231,18 +231,14 @@ class SensitivityList:
         """Return the number of the SensitivityFactors in the object."""
         return len(self.sf_list)
 
-    def __add__(
-            self,
-            other: Union[SensitivityFactor, "SensitivityList"]
-    ) -> "SensitivityList":
+    def __add__(self, other: Union[SensitivityFactor, "SensitivityList"]) -> "SensitivityList":
         """Return a `SensitivityList` with the sensitivity factors of self and ``other``.
 
         You can add SensitivityFactor, CalPoint, SensitivityList, or Calibration to a
         SensitivityList or Calibration.
         If either self or other is a Calibration, the result will be a Calibration.
         """
-        if self.__class__ is not other.__class__ and\
-                issubclass(other.__class__, self.__class__):
+        if self.__class__ is not other.__class__ and issubclass(other.__class__, self.__class__):
             # This ensures that SensitivityList + Calibration -> Calibration
             return other + self
 

--- a/src/spectro_inlets_quantification/signal.py
+++ b/src/spectro_inlets_quantification/signal.py
@@ -297,17 +297,20 @@ class SignalProcessor:
         self.medium = Medium()
         self.verbose = verbose
 
-    def save(self, proc_dir: Optional[PATH_OR_STR] = None,
-             file_name: Optional[str] = None) -> None:
-        """Save the `as_dict` form of the molecule to a yaml file.
+    def save(
+        self,
+        file_name: str,
+        proc_dir: Optional[PATH_OR_STR] = None,
+    ) -> None:
+        """Save the `as_dict` form of the signal processor to a yaml file.
 
-        Saves in `CONFIG.aux_data_directory / "molecules"` by default. This is the
-        user's quant data library (as opposed to the included library).
+        Saves in `CONFIG.aux_data_directory / "processors"` if it is set (this is the
+        user's quant data library, as opposed to the included library). If it is not set,
+        saves in `CONFIG.data_directory / "processors"`.
 
         Args:
-            proc_dir: Path to directory to save processor in, defaults to
-                :attr:`Config.processor_directory`
             file_name: Name of the yaml file, including the file extension ".yml"
+            proc_dir: Path to directory to save processor in. Defaults as outlines above.
         """
         file_name_with_suffix = Path(file_name).with_suffix(".yml")
         path_to_yaml = CONFIG.get_save_destination(
@@ -337,8 +340,8 @@ class SignalProcessor:
         except ValueError as value_error:
             raise ValueError(
                 f"Can't find a processor named '{file_name}'. Please consider providing an "
-                "`aux_data_directory` (which contains a 'molecules' folder) to "
-                "`config.Config` or a ``mol_dir`` to this method, either of which contains "
+                "`aux_data_directory` (which contains a 'processors' folder) to "
+                "`config.Config` or a ``proc_dir`` to this method, either of which contains "
                 "the molecule file."
             ) from value_error
 

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -27,24 +27,6 @@ def test_data_directory_property(reset_singletons):
     assert config.data_directory == obj2
 
 
-@pytest.mark.parametrize("name", ("chip", "calibration", "molecule", "processor"))
-def test_directories_properties(reset_singletons, name) -> None:
-    """Test the chip_directory property"""
-    path = Path("test")
-    config = Config(path)
-    assert getattr(config, f"{name}_directories") == [path / f"{name}s"]
-
-
-@pytest.mark.parametrize("name", ("chip", "calibration", "molecule", "processor"))
-def test_directories_properties_with_aux(reset_singletons, name) -> None:
-    """Test the chip_directory property"""
-    path = Path("test")
-    aux_path = Path("auxxx")
-    config = Config(path)
-    config.aux_data_directory = aux_path
-    assert getattr(config, f"{name}_directories") == [aux_path / f"{name}s", path / f"{name}s"]
-
-
 def test_get_best_data_file_bad_type():
     config = Config("path")
     with pytest.raises(ValueError):

--- a/tests/unittests/test_molecule.py
+++ b/tests/unittests/test_molecule.py
@@ -44,18 +44,18 @@ class TestMoleculeDict:
 
     def test_attrs_post_init(self):
         """Test __attrs_post_init__"""
-        molecule = Molecule()
+        molecule = Molecule("Ar")
         assert molecule.spectrum is None
         assert molecule.T_of_M is None
-        molecule = Molecule(beta=0.8)
+        molecule = Molecule("Ar", beta=0.8)
         assert molecule.T_of_M is not None
         assert molecule.T_of_M(3.0) == approx(3.0**0.8)
-        molecule = Molecule(spectrum_0={"a": 47, "b": 42})
+        molecule = Molecule("Ar", spectrum_0={"a": 47, "b": 42})
         assert molecule.spectrum == molecule.spectrum_0
 
     def test_as_dict(self):
         """Test as dict"""
-        as_dict = Molecule().as_dict()
+        as_dict = Molecule("Ar").as_dict()
         fields_ = fields(Molecule)
         field_names = {f.name for f in fields_ if f.init and f.metadata.get("serialize", True)}
         field_names == as_dict.keys()

--- a/tests/unittests/test_molecule.py
+++ b/tests/unittests/test_molecule.py
@@ -86,7 +86,7 @@ class TestMoleculeDict:
             with patch.object(molecule, "as_dict") as mock_as_dict:
                 mock_as_dict.return_value = {"a": 47}
                 get_save_destination.return_value = "Some_path.yml"
-                molecule.save(mol_dir=mol_dir, file_name=file_name)
+                molecule.save(file_name=file_name, mol_dir=mol_dir)
 
         get_save_destination.assert_called_once_with(
             data_file_type="molecules",

--- a/tests/unittests/test_signal.py
+++ b/tests/unittests/test_signal.py
@@ -349,9 +349,7 @@ class TestSignalProcessor:
             init_kwargs["proc_dir"] = proc_dir
 
         # expected_proc_dir = proc_dir if proc_dir else CONFIG.processor_directories[0]
-        expected_filename = Path((file_name if file_name else "Sorens final processor") +
-                               ".json")
-
+        expected_filename = Path((file_name if file_name else "Sorens final processor") + ".yml")
 
         with patch("spectro_inlets_quantification.config.Config.get_best_data_file") as get_best:
             get_best.return_value = Path("Best")
@@ -359,8 +357,7 @@ class TestSignalProcessor:
                 signal_processor_init.return_value = None
                 SignalProcessor.load(**init_kwargs)
         get_best.assert_called_once_with(
-            data_file_type="processors", filepath=expected_filename,
-            override_source_dir=proc_dir
+            data_file_type="processors", filepath=expected_filename, override_source_dir=proc_dir
         )
 
         mock_open.assert_called_once_with(Path("Best"), "r")


### PR DESCRIPTION
This PR contains some fixes for #1. There were some lint and black fixes, but the more significant is changes to some of the save methods, where code had been copied around (by me) without any concern for whether the `file_name` argument was required or not. Note that for at least one of the save methods, this error was caught in tests, which I guess means we should have placed better emphasis on passing tests before merging.

**IMPORTANT** the signature of the newly added `SignalProcessor.save` had to change, since it has no name property, the `file_name` argument had to be mandatory and therefore first in order. If any code in the ixdat PR depends in it, please update that PR.

The change above, brings about another discussion, which is one of consistent interfaces. All four `save` methods takes `file_name` as the first argument (some mandatory, some not) followed by the override save dir **except** for Molecules save, in which the order is reversed. I'd like to fix that now and will add it as a commit on top of this PR if you agree @ScottSoren.